### PR TITLE
refactor endpoints to include user auth

### DIFF
--- a/app/routers/portfolios.py
+++ b/app/routers/portfolios.py
@@ -34,7 +34,7 @@ async def get_portfolio_holdings(
     result = await session.execute(
         select(Portfolio).where(
             Portfolio.portfolioId == portfolioid,
-            Portfolio.userId == current_user.id  
+            Portfolio.userId == current_user.userId  
         )
     )
     portfolio = result.scalar_one_or_none()
@@ -60,7 +60,7 @@ async def get_portfolio_transactions(
     result = await session.execute(
         select(Portfolio).where(
             Portfolio.portfolioId == portfolioid,
-            Portfolio.userId == current_user.id
+            Portfolio.userId == current_user.userId
         )
     )
     portfolio = result.scalar_one_or_none()

--- a/app/routers/portfolios.py
+++ b/app/routers/portfolios.py
@@ -4,52 +4,69 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from app.core.db import get_session
+from app.core.dependencies import get_current_user
 from app.models.portfolio import Portfolio
+from app.models.user import User
 from app.models.holding import Holding
 from app.models.transaction import Transaction
 from app.schemas.holding import HoldingOut
 from app.schemas.transaction import TransactionOut
 
+
 router = APIRouter(prefix="/portfolios", tags=["portfolios"])
 
+
 @router.get("/{portfolioid}/holdings", response_model=List[HoldingOut], status_code=status.HTTP_200_OK)
-async def get_portfolio_holdings(portfolioid: int, session: AsyncSession = Depends(get_session)):
+async def get_portfolio_holdings(
+    portfolioid: int,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
     """
     @brief Retrieve all holdings for a given portfolio.
 
     @param portfolioid int The portfolio identifier.
+    @param current_user User The current user
     @param session AsyncSession Database session dependency.
     @return List[HoldingOut] List of holdings associated with the portfolio.
     @throws HTTPException 404 if the portfolio is not found.
     """
-    result = await session.execute(select(Portfolio).where(Portfolio.portfolioId == portfolioid))
+    result = await session.execute(
+        select(Portfolio).where(
+            Portfolio.portfolioId == portfolioid,
+            Portfolio.userId == current_user.id  
+        )
+    )
     portfolio = result.scalar_one_or_none()
     if not portfolio:
-        raise HTTPException(status_code=404, detail="Portfolio not found")
+        raise HTTPException(status_code=404, detail="Portfolio not found or unauthorized")
 
-    # get all holdings
     result = await session.execute(
         select(Holding).where(Holding.portfolioId == portfolioid).order_by(Holding.holdingId)
     )
     holdings = result.scalars().all()
     return holdings
 
-@router.get("/{portfolioid}/transactions", response_model=List[TransactionOut], status_code=status.HTTP_200_OK)
-async def get_portfolio_transactions(portfolioid: int, session: AsyncSession = Depends(get_session)):
-    """
-    @brief Retrieve all transactions tied to a given portfolio.
 
-    @param portfolioid int The portfolio identifier.
-    @param session AsyncSession Database session dependency.
-    @return List[TransactionOut] List of transactions associated with the portfolio.
-    @throws HTTPException 404 if the portfolio is not found.
+@router.get("/{portfolioid}/transactions", response_model=List[TransactionOut], status_code=status.HTTP_200_OK)
+async def get_portfolio_transactions(
+    portfolioid: int,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
     """
-    result = await session.execute(select(Portfolio).where(Portfolio.portfolioId == portfolioid))
+    Retrieve all transactions for a given portfolio that belongs to the current user.
+    """
+    result = await session.execute(
+        select(Portfolio).where(
+            Portfolio.portfolioId == portfolioid,
+            Portfolio.userId == current_user.id
+        )
+    )
     portfolio = result.scalar_one_or_none()
     if not portfolio:
-        raise HTTPException(status_code=404, detail="Portfolio not found")
+        raise HTTPException(status_code=404, detail="Portfolio not found or unauthorized")
 
-    # get all transactions
     result = await session.execute(
         select(Transaction).where(Transaction.portfolioId == portfolioid).order_by(Transaction.transactionId)
     )


### PR DESCRIPTION
Previously anybody could send a request to our apis with any user ID and see that person's data. 

In this pr we refactor our backend apis to handle validation of user requests.

<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/59365a04-6934-484d-9b9d-e1bcf0699d9a" />
<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/e19b4506-036f-4d0d-97c1-9d9e4088e1f1" />
<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/7aba793e-a6fc-448b-adbd-bd43b89d6962" />
