### PR TITLE
added api tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app ./app
+COPY tests ./tests
+COPY pytest.ini .
 
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/routers/portfolios.py
+++ b/app/routers/portfolios.py
@@ -72,3 +72,5 @@ async def get_portfolio_transactions(
     )
     transactions = result.scalars().all()
     return transactions
+
+

--- a/app/schemas/transaction.py
+++ b/app/schemas/transaction.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field, ConfigDict
 from typing import Literal
 import datetime
+from decimal import Decimal
 from app.models.transaction import TransactionType
 
 class TransactionPayload(BaseModel):
@@ -8,7 +9,7 @@ class TransactionPayload(BaseModel):
     portfolio_id: int
     ticker_id: int
     type: Literal["BUY", "SELL"]
-    price_per_share: float = Field(..., gt=0)
+    price_per_share: Decimal = Field(..., gt=0)
     quantity: int = Field(..., gt=0)
     timestamp: datetime.datetime
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+asyncio_mode = auto
+pythonpath = .
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,7 @@ uvicorn==0.30.6
 uvloop==0.22.1
 watchfiles==1.1.1
 websockets==15.0.1
+pytest==9.0.2
+pytest-asyncio==1.3.0
+httpx==0.28.1
+aiosqlite==0.22.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,88 @@
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.core.db import get_session
+from app.core.dependencies import get_current_user
+from app.models.base import Base  
+from app.models.user import User
+from app.models.ticker import Ticker
+from app.models.portfolio import Portfolio
+
+
+DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+engine = create_async_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+TestingSessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest_asyncio.fixture(scope="function", autouse=True)
+async def setup_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest_asyncio.fixture
+async def session():
+    async with TestingSessionLocal() as s:
+        yield s
+
+
+# Override DB session
+async def override_get_session():
+    async with TestingSessionLocal() as s:
+        yield s
+
+
+# Override auth — returns a fake user
+def make_auth_override(user: User):
+    def override():
+        return user
+    return override
+
+
+@pytest_asyncio.fixture
+async def seeded_user(session: AsyncSession) -> User:
+    user = User(userId=1, email="test@example.com", password="x")
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+@pytest_asyncio.fixture
+async def seeded_ticker(session: AsyncSession) -> Ticker:
+    ticker = Ticker(ticker_id=1, symbol="AAPL", name="Apple Inc.")
+    session.add(ticker)
+    await session.commit()
+    await session.refresh(ticker)
+    return ticker
+
+
+@pytest_asyncio.fixture
+async def seeded_portfolio(session: AsyncSession, seeded_user: User) -> Portfolio:
+    portfolio = Portfolio(portfolioId=1, userId=seeded_user.userId, name="My Portfolio", description="Test")
+    session.add(portfolio)
+    await session.commit()
+    await session.refresh(portfolio)
+    return portfolio
+
+
+@pytest_asyncio.fixture
+async def client(seeded_user: User) -> AsyncClient:
+    app.dependency_overrides[get_session] = override_get_session
+    app.dependency_overrides[get_current_user] = make_auth_override(seeded_user)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()

--- a/tests/test_portfolios.py
+++ b/tests/test_portfolios.py
@@ -1,0 +1,41 @@
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_get_user_portfolios_empty(client: AsyncClient):
+    response = await client.get("/users/portfolios")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_create_portfolio(client: AsyncClient):
+    response = await client.post("/users/portfolios", json={
+        "name": "Growth Portfolio",
+        "description": "Long-term holdings"
+    })
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "Growth Portfolio"
+    assert "portfolioId" in data
+
+
+@pytest.mark.asyncio
+async def test_get_portfolio_holdings_not_found(client: AsyncClient):
+    response = await client.get("/portfolios/9999/holdings")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_portfolio_holdings_empty(client: AsyncClient, seeded_portfolio):
+    response = await client.get(f"/portfolios/{seeded_portfolio.portfolioId}/holdings")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_get_portfolio_transactions_empty(client: AsyncClient, seeded_portfolio):
+    response = await client.get(f"/portfolios/{seeded_portfolio.portfolioId}/transactions")
+    assert response.status_code == 200
+    assert response.json() == []

--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -1,0 +1,44 @@
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_get_tickers_empty(client: AsyncClient):
+    response = await client.get("/ticker/")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_get_tickers_returns_seeded(client: AsyncClient, seeded_ticker):
+    response = await client.get("/ticker/")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["symbol"] == "AAPL"
+
+
+@pytest.mark.asyncio
+async def test_get_ticker_by_id(client: AsyncClient, seeded_ticker):
+    response = await client.get(f"/ticker/{seeded_ticker.ticker_id}")
+    assert response.status_code == 200
+    assert response.json()["symbol"] == "AAPL"
+
+
+@pytest.mark.asyncio
+async def test_get_ticker_by_id_not_found(client: AsyncClient):
+    response = await client.get("/ticker/9999")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_ticker_by_symbol(client: AsyncClient, seeded_ticker):
+    response = await client.get("/ticker/symbol/AAPL")
+    assert response.status_code == 200
+    assert response.json()["name"] == "Apple Inc."
+
+
+@pytest.mark.asyncio
+async def test_get_ticker_by_symbol_not_found(client: AsyncClient, seeded_ticker):
+    response = await client.get("/ticker/symbol/FAKE")
+    assert response.status_code == 404

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,0 +1,67 @@
+import pytest
+from httpx import AsyncClient
+from datetime import datetime
+
+
+PAYLOAD = {
+    "user_id": 1,          
+    "portfolio_id": 1,
+    "ticker_id": 1,
+    "timestamp": datetime.utcnow().isoformat(),
+}
+
+@pytest.mark.asyncio
+async def test_buy_creates_holding(client: AsyncClient, seeded_portfolio):
+    response = await client.post("/transactions/", json={**PAYLOAD, "price_per_share": 150, "quantity": 10, "type": "BUY"})
+    assert response.status_code == 201
+    assert response.json()["status"] == "success"
+
+    # Verify holding was created
+    holdings = await client.get(f"/portfolios/{seeded_portfolio.portfolioId}/holdings")
+    assert holdings.status_code == 200
+    data = holdings.json()
+    assert len(data) == 1
+    assert data[0]["quantity"] == 10
+    assert data[0]["averagePrice"] == 150.00
+
+async def test_buy_updates_average_price(client: AsyncClient, seeded_portfolio):
+    await client.post("/transactions/", json={**PAYLOAD, "price_per_share": 100.00, "quantity": 10, "type": "BUY"})
+    await client.post("/transactions/", json={**PAYLOAD, "price_per_share": 200.00, "quantity": 10, "type": "BUY"})
+
+    holdings = await client.get("/portfolios/1/holdings")
+
+    data = holdings.json()
+    assert data[0]["averagePrice"] == 150.00
+    assert data[0]["quantity"] == 20
+
+@pytest.mark.asyncio
+async def test_sell_without_holding_returns_400(client: AsyncClient, seeded_portfolio):
+    response = await client.post("/transactions/", json={**PAYLOAD, "price_per_share": 100.00, "quantity": 10, "type": "SELL"})
+    assert response.status_code == 400
+    assert "No holding found to sell" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_sell_insufficient_quantity_returns_400(client: AsyncClient, seeded_portfolio):
+    await client.post("/transactions/", json={**PAYLOAD, "price_per_share": 100.00, "quantity": 5, "type":"BUY"})
+
+    response = await client.post("/transactions/", json={**PAYLOAD, "price_per_share": 100.00, "quantity": 10, "type": "SELL"})
+
+    assert response.status_code == 400
+    assert "Insufficient" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_sell_removes_holding_when_quantity_zero(client: AsyncClient, seeded_portfolio):
+    await client.post("/transactions/", json={**PAYLOAD,"price_per_share": 100.00, "quantity": 10, "type": "BUY"})
+    response = await client.post("/transactions/", json={**PAYLOAD, "price_per_share": 100.00, "quantity": 10, "type": "SELL"})
+    assert response.status_code == 201
+
+    holdings = await client.get("/portfolios/1/holdings")
+    assert holdings.json() == []
+
+
+@pytest.mark.asyncio
+async def test_transaction_invalid_portfolio_returns_404(client: AsyncClient, seeded_portfolio):
+    response = await client.post("/transactions/", json={**PAYLOAD, "price_per_share": 100.00, "quantity":10, "portfolio_id": 9999, "type": "BUY"})
+    assert response.status_code == 404


### PR DESCRIPTION
This PR introduces regression tests for our core APIs using an in-memory SQLite database and updates the Docker configuration to support test execution within the containerized environment.

Implemented regression tests for the following APIs:
-Transaction API
-Users API
-Tickers API
-Portfolio API

<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/5075d98f-2132-49fd-b6c1-e5d09e639b83" />
